### PR TITLE
Feat: Add Desert Mobs module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.10-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
     implementation("org.incendo:cloud-paper:2.0.0-beta.10")
     implementation("org.incendo:cloud-annotations:2.0.0")
     implementation("com.fasterxml.jackson.core:jackson-core:2.20.0-rc1")
@@ -68,7 +68,7 @@ processResources {
 }
 
 runServer {
-    minecraftVersion("1.21.10")
+    minecraftVersion("1.21.11")
     jvmArgs("-Dcom.mojang.eula.agree=true")
 }
 

--- a/src/main/java/com/nearvanilla/iceCream/IceCream.java
+++ b/src/main/java/com/nearvanilla/iceCream/IceCream.java
@@ -1,5 +1,6 @@
 package com.nearvanilla.iceCream;
 
+import com.nearvanilla.iceCream.modules.desertMobs.DesertMobsModule;
 import com.nearvanilla.iceCream.modules.example.ExampleModule;
 import com.nearvanilla.iceCream.modules.isSlimeChunk.isSlimeChunkModule;
 import com.nearvanilla.iceCream.modules.lightning.LightningModule;
@@ -38,6 +39,7 @@ public final class IceCream extends JavaPlugin {
   public static PaperCommandManager<CommandSourceStack> commandManager;
   public static AnnotationParser<CommandSourceStack> annotationParser;
   // Modules
+  private final DesertMobsModule desertMobsModule = new DesertMobsModule();
   private final ExampleModule exampleModule = new ExampleModule();
   private final LightningModule lightningModule = new LightningModule();
   private final MuteDeathsModule muteDeathsModule = new MuteDeathsModule();
@@ -60,6 +62,7 @@ public final class IceCream extends JavaPlugin {
     this.saveDefaultConfig();
     config = this.getConfig();
     // Register modules
+    desertMobsModule.register();
     exampleModule.register();
     lightningModule.register();
     muteDeathsModule.register();

--- a/src/main/java/com/nearvanilla/iceCream/modules/desertMobs/DesertMobsModule.java
+++ b/src/main/java/com/nearvanilla/iceCream/modules/desertMobs/DesertMobsModule.java
@@ -1,0 +1,59 @@
+package com.nearvanilla.iceCream.modules.desertMobs;
+
+import com.nearvanilla.iceCream.IceCream;
+import com.nearvanilla.iceCream.modules.Module;
+import com.nearvanilla.iceCream.modules.desertMobs.events.DesertMobsSpawnEvent;
+
+/**
+ * DesertMobsModule adds custom behavior for desert mobs. It adds a configurable chance for zombies
+ * and skeletons spawning in desert biomes to convert to Husks and Parched respectively.
+ *
+ * @author Dynant
+ * @version 1.0
+ * @since 2026-02-26
+ * @see Module
+ * @see DesertMobsSpawnEvent
+ */
+public class DesertMobsModule implements Module {
+  protected boolean isEnabled = false;
+
+  @Override
+  public boolean shouldEnable() {
+    return IceCream.config.getBoolean("modules.desertmobs.enabled", false);
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return isEnabled;
+  }
+
+  @Override
+  public void registerCommands() {
+    // No commands to register for this module.
+  }
+
+  @Override
+  public void registerEvents() {
+    IceCream.instance
+        .getServer()
+        .getPluginManager()
+        .registerEvents(new DesertMobsSpawnEvent(), IceCream.instance);
+  }
+
+  @Override
+  public void register() {
+    if (shouldEnable()) {
+      try {
+        registerCommands();
+        registerEvents();
+        isEnabled = true;
+      } catch (Exception e) {
+        IceCream.logger.severe("Failed to register Desert Mobs module: " + e.getMessage());
+        return;
+      }
+      IceCream.logger.info("Desert Mobs module has been enabled.");
+    } else {
+      IceCream.logger.info("Desert Mobs module is disabled.");
+    }
+  }
+}

--- a/src/main/java/com/nearvanilla/iceCream/modules/desertMobs/events/DesertMobsSpawnEvent.java
+++ b/src/main/java/com/nearvanilla/iceCream/modules/desertMobs/events/DesertMobsSpawnEvent.java
@@ -1,0 +1,62 @@
+package com.nearvanilla.iceCream.modules.desertMobs.events;
+
+import com.nearvanilla.iceCream.IceCream;
+import java.util.concurrent.ThreadLocalRandom;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Biome;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+
+/**
+ * Listens for creature spawns and converts zombies/skeletons in desert biomes to Husks/Parched with
+ * a configurable chance.
+ *
+ * @author Dynant
+ * @version 1.0
+ * @since 2026-02-26
+ */
+public class DesertMobsSpawnEvent implements Listener {
+
+  @EventHandler
+  public void onCreatureSpawn(CreatureSpawnEvent event) {
+    EntityType entityType = event.getEntityType();
+    Location location = event.getLocation();
+    World world = location.getWorld();
+
+    if (world == null) return;
+
+    // Check if the spawn location is in a desert biome
+    Biome biome = world.getBiome(location);
+    if (biome != Biome.DESERT) return;
+
+    // Handle zombie -> husk conversion
+    if (entityType == EntityType.ZOMBIE) {
+      double chance =
+          IceCream.config.getDouble("modules.desertmobs.spawn.zombie-to-husk-chance", 0.0);
+
+      if (chance <= 0.0) return;
+
+      if (ThreadLocalRandom.current().nextDouble() < chance) {
+        event.setCancelled(true);
+        world.spawnEntity(location, EntityType.HUSK, CreatureSpawnEvent.SpawnReason.NATURAL);
+      }
+      return;
+    }
+
+    // Handle skeleton -> parched conversion
+    if (entityType == EntityType.SKELETON) {
+      double chance =
+          IceCream.config.getDouble("modules.desertmobs.spawn.skeleton-to-parched-chance", 0.0);
+
+      if (chance <= 0.0) return;
+
+      if (ThreadLocalRandom.current().nextDouble() < chance) {
+        event.setCancelled(true);
+        world.spawnEntity(location, EntityType.PARCHED, CreatureSpawnEvent.SpawnReason.NATURAL);
+      }
+    }
+  }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,6 +29,11 @@ modules:
         - staff
         - staffchat
         - sc
+  desertmobs:
+    enabled: true
+    spawn:
+      zombie-to-husk-chance: 0.33
+      skeleton-to-parched-chance: 0.33
   wanderful:
     enabled: true
     item_frame:


### PR DESCRIPTION
Converts zombies and skeletons spawning in desert biomes to Husks and Parched respectively, with a configurable chance per mob type. Also updates Paper API and server version to 1.21.11.

## Added
- [ ] Desert Mobs Module