### PR TITLE
Add world tour module

### DIFF
--- a/src/main/java/com/nearvanilla/iceCream/IceCream.java
+++ b/src/main/java/com/nearvanilla/iceCream/IceCream.java
@@ -11,6 +11,7 @@ import com.nearvanilla.iceCream.modules.spectator.SpectatorModule;
 import com.nearvanilla.iceCream.modules.staffMode.StaffModeModule;
 import com.nearvanilla.iceCream.modules.wanderful.WanderfulModule;
 import com.nearvanilla.iceCream.modules.wanderingTrades.WanderingTradesModule;
+import com.nearvanilla.iceCream.modules.worldTour.WorldTourModule;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import java.util.logging.Logger;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -52,6 +53,7 @@ public final class IceCream extends JavaPlugin {
   private final StaffModeModule staffModeModule = new StaffModeModule();
   private final SpectatorModule spectatorModule = new SpectatorModule();
   private final ReadOnlyLecternModule readOnlyLecternModule = new ReadOnlyLecternModule();
+  private final WorldTourModule worldTourModule = new WorldTourModule();
 
   @Override
   public void onEnable() {
@@ -80,13 +82,14 @@ public final class IceCream extends JavaPlugin {
     wanderfulModule.register();
     wanderingTradesModule.register();
     staffModeModule.register();
-
     spectatorModule.register();
     readOnlyLecternModule.register();
+    worldTourModule.register();
   }
 
   @Override
   public void onDisable() {
     spectatorModule.unregister();
+    worldTourModule.unregister();
   }
 }

--- a/src/main/java/com/nearvanilla/iceCream/modules/worldTour/WorldTourModule.java
+++ b/src/main/java/com/nearvanilla/iceCream/modules/worldTour/WorldTourModule.java
@@ -1,0 +1,437 @@
+package com.nearvanilla.iceCream.modules.worldTour;
+
+import com.nearvanilla.iceCream.IceCream;
+import com.nearvanilla.iceCream.modules.Module;
+import com.nearvanilla.iceCream.modules.worldTour.commands.WorldTourCommand;
+import com.nearvanilla.iceCream.modules.worldTour.events.WorldTourListener;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.GameRules;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * WorldTourModule provides commands and features for hosting World Tours, including join/leave
+ * opt-in, host designation, teleportation, weather/time control across loaded worlds with
+ * original-state preservation, and a failsafe that cleans up disconnected players after a
+ * configurable timeout.
+ *
+ * @author Demonstrations
+ * @version 1.0
+ * @since 2026-06-26
+ * @see Module
+ * @see WorldTourCommand
+ * @see WorldTourListener
+ */
+public class WorldTourModule implements Module {
+
+  /** PDC key marking a player as opted into the World Tour. */
+  public static NamespacedKey JOINED_KEY;
+
+  private boolean isEnabled = false;
+
+  /** The current World Tour host, or {@code null} if no host is set. */
+  Player currentHost;
+
+  /** The player currently bearing the Glowing effect, or {@code null}. */
+  Player currentGlowing;
+
+  /** Original weather values per world, saved before the first tour weather change. */
+  private final Map<String, WeatherSnapshot> originalWeather = new HashMap<>();
+
+  /** Original full time values per world, saved before the first tour time change. */
+  private final Map<String, Long> originalTimes = new HashMap<>();
+
+  /** Original keepInventory gamerule values per world, saved before the tour started. */
+  private final Map<String, Boolean> originalKeepInventory = new HashMap<>();
+
+  /** Active failsafe tasks keyed by player UUID. */
+  final Map<UUID, BukkitTask> disconnectTasks = new HashMap<>();
+
+  /** Configurable timeout in minutes for the disconnect failsafe. */
+  private int failsafeTimeoutMinutes;
+
+  /** Configurable start time in ticks for the World Tour. */
+  private long startTimeTicks;
+
+  /** Configurable time command aliases in ticks. */
+  private final Map<String, Long> configuredTimes = new HashMap<>();
+
+  /** Pending takeover requests, keyed by current host UUID, value is requester UUID. */
+  final Map<UUID, UUID> pendingTakeovers = new HashMap<>();
+
+  private static final class WeatherSnapshot {
+    private final boolean storm;
+    private final boolean thundering;
+    private final int weatherDuration;
+    private final int thunderDuration;
+
+    private WeatherSnapshot(World world) {
+      this.storm = world.hasStorm();
+      this.thundering = world.isThundering();
+      this.weatherDuration = world.getWeatherDuration();
+      this.thunderDuration = world.getThunderDuration();
+    }
+  }
+
+  private static void initKeys() {
+    if (JOINED_KEY != null) return;
+    JOINED_KEY = new NamespacedKey(IceCream.instance, "worldtour.joined");
+  }
+
+  @Override
+  public boolean shouldEnable() {
+    return IceCream.config.getBoolean("modules.worldtour.enabled", false);
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return isEnabled;
+  }
+
+  @Override
+  public void registerCommands() {
+    IceCream.annotationParser.parse(new WorldTourCommand(this));
+  }
+
+  @Override
+  public void registerEvents() {
+    IceCream.instance
+        .getServer()
+        .getPluginManager()
+        .registerEvents(new WorldTourListener(this), IceCream.instance);
+  }
+
+  @Override
+  public void register() {
+    if (shouldEnable()) {
+      try {
+        initKeys();
+        registerCommands();
+        registerEvents();
+        failsafeTimeoutMinutes =
+            Math.max(1, IceCream.config.getInt("modules.worldtour.failsafe-timeout-minutes", 5));
+
+        configuredTimes.clear();
+        configuredTimes.put("day", getConfiguredTimeTicks("day", 1000L));
+        configuredTimes.put("noon", getConfiguredTimeTicks("noon", 6000L));
+        configuredTimes.put("night", getConfiguredTimeTicks("night", 13000L));
+        configuredTimes.put("midnight", getConfiguredTimeTicks("midnight", 18000L));
+
+        startTimeTicks =
+            Math.floorMod(
+                IceCream.config.getLong(
+                    "modules.worldtour.start-time-ticks", configuredTimes.get("day")),
+                24000L);
+        isEnabled = true;
+      } catch (Exception e) {
+        IceCream.logger.severe("Failed to register World Tour module: " + e.getMessage());
+        return;
+      }
+      IceCream.logger.info("World Tour module has been enabled.");
+    } else {
+      IceCream.logger.info("World Tour module is disabled.");
+    }
+  }
+
+  private long getConfiguredTimeTicks(String name, long defaultTicks) {
+    return Math.floorMod(
+        IceCream.config.getLong("modules.worldtour.times." + name, defaultTicks), 24000L);
+  }
+
+  /**
+   * Cleans up the World Tour module. Cancels all pending failsafe tasks, clears the host, and
+   * restores weather/time across loaded worlds if they were altered.
+   */
+  public void unregister() {
+    cancelAllDisconnectTasks();
+    clearHost(true);
+    isEnabled = false;
+  }
+
+  /**
+   * @return the current host, or {@code null} if no host is set
+   */
+  public Player getCurrentHost() {
+    return currentHost;
+  }
+
+  /**
+   * @return the player currently bearing the Glowing effect, or {@code null}
+   */
+  public Player getCurrentGlowing() {
+    return currentGlowing;
+  }
+
+  /**
+   * @return the configured disconnect failsafe timeout in minutes
+   */
+  public int getFailsafeTimeoutMinutes() {
+    return failsafeTimeoutMinutes;
+  }
+
+  /**
+   * @return the configured World Tour start time in ticks
+   */
+  public long getStartTimeTicks() {
+    return startTimeTicks;
+  }
+
+  /**
+   * Gets a configured time alias in ticks.
+   *
+   * @param type the configured time type, such as day, noon, night, or midnight
+   * @return the configured time in ticks
+   */
+  public long getTimeTicks(String type) {
+    Long ticks = configuredTimes.get(type);
+    if (ticks == null) {
+      throw new IllegalArgumentException("Unknown time type: " + type);
+    }
+    return ticks;
+  }
+
+  /**
+   * Stores a pending takeover request from a requester targeting a host.
+   *
+   * @param hostId the current host's UUID
+   * @param requesterId the requesting player's UUID
+   */
+  public void setPendingTakeover(UUID hostId, UUID requesterId) {
+    pendingTakeovers.put(hostId, requesterId);
+  }
+
+  /**
+   * Removes and returns the pending takeover requester for a host.
+   *
+   * @param hostId the host's UUID
+   * @return the requester's UUID, or {@code null} if none
+   */
+  public UUID removePendingTakeover(UUID hostId) {
+    return pendingTakeovers.remove(hostId);
+  }
+
+  /**
+   * Sets the current host. If a different host is already set, notifies the previous host of the
+   * takeover.
+   *
+   * @param player the player to set as host
+   */
+  public void setCurrentHost(Player player) {
+    if (currentHost != null && !currentHost.equals(player)) {
+      currentHost.sendMessage(
+          net.kyori.adventure.text.Component.text(
+              player.getName() + " has taken over as World Tour host."));
+    }
+    currentHost = player;
+  }
+
+  /**
+   * Clears the current host and, if {@code restoreEnvironment} is true, restores original weather
+   * and time across loaded worlds.
+   *
+   * @param restoreEnvironment whether to restore weather and time to pre-tour values
+   */
+  public void clearHost(boolean restoreEnvironment) {
+    if (currentHost == null) return;
+    pendingTakeovers.remove(currentHost.getUniqueId());
+    if (restoreEnvironment) {
+      restoreWeather();
+      restoreTime();
+      restoreKeepInventory();
+    }
+    clearGlowing();
+    currentHost = null;
+  }
+
+  /**
+   * Ends the tour: clears the host, restores environment, removes all participants, and notifies
+   * them.
+   */
+  public void endTour() {
+    clearHost(true);
+    for (Player online : IceCream.instance.getServer().getOnlinePlayers()) {
+      if (Boolean.TRUE.equals(
+          online.getPersistentDataContainer().get(JOINED_KEY, PersistentDataType.BOOLEAN))) {
+        online.getPersistentDataContainer().set(JOINED_KEY, PersistentDataType.BOOLEAN, false);
+        online.sendMessage(
+            MiniMessage.miniMessage()
+                .deserialize(
+                    "<gold>✨ The World Tour has concluded. Thank you for participating!</gold>"));
+      }
+    }
+  }
+
+  /** Removes the Glowing effect from whoever currently has it and clears the tracking reference. */
+  public void clearGlowing() {
+    if (currentGlowing != null) {
+      currentGlowing.removePotionEffect(PotionEffectType.GLOWING);
+    }
+    currentGlowing = null;
+  }
+
+  /**
+   * Transfers the Glowing effect to a new player, removing it from the previous holder.
+   *
+   * @param player the player to apply Glowing to
+   */
+  public void setGlowing(Player player) {
+    clearGlowing();
+    currentGlowing = player;
+    player.addPotionEffect(
+        new PotionEffect(PotionEffectType.GLOWING, Integer.MAX_VALUE, 1, false, false));
+  }
+
+  /** Saves the current weather for every loaded world before modification. */
+  public void saveWeather() {
+    if (!originalWeather.isEmpty()) return;
+    for (World world : IceCream.instance.getServer().getWorlds()) {
+      originalWeather.put(world.getName(), new WeatherSnapshot(world));
+    }
+  }
+
+  /** Applies clear weather across every loaded world. */
+  public void setClearWeather() {
+    setWeather(false, false);
+  }
+
+  /** Applies the requested weather state across every loaded world. */
+  public void setWeather(String type) {
+    switch (type) {
+      case "clear" -> setWeather(false, false);
+      case "rain" -> setWeather(true, false);
+      case "thunder" -> setWeather(true, true);
+      default -> throw new IllegalArgumentException("Unknown weather type: " + type);
+    }
+  }
+
+  private void setWeather(boolean storm, boolean thundering) {
+    saveWeather();
+    for (World world : IceCream.instance.getServer().getWorlds()) {
+      world.setStorm(storm);
+      world.setThundering(thundering);
+    }
+  }
+
+  /** Restores weather in every loaded world to the values saved before the tour changed it. */
+  public void restoreWeather() {
+    if (originalWeather.isEmpty()) return;
+    for (World world : IceCream.instance.getServer().getWorlds()) {
+      WeatherSnapshot snapshot = originalWeather.get(world.getName());
+      if (snapshot != null) {
+        world.setStorm(snapshot.storm);
+        world.setThundering(snapshot.thundering);
+        world.setWeatherDuration(snapshot.weatherDuration);
+        world.setThunderDuration(snapshot.thunderDuration);
+      }
+    }
+    originalWeather.clear();
+  }
+
+  /** Saves the current full time for every loaded world before modification. */
+  public void saveTime() {
+    if (!originalTimes.isEmpty()) return;
+    for (World world : IceCream.instance.getServer().getWorlds()) {
+      originalTimes.put(world.getName(), world.getFullTime());
+    }
+  }
+
+  /** Applies the requested time of day across every loaded world. */
+  public void setTime(long ticks) {
+    saveTime();
+    for (World world : IceCream.instance.getServer().getWorlds()) {
+      world.setTime(ticks);
+    }
+  }
+
+  /** Restores full time in every loaded world to the values saved before the tour changed it. */
+  public void restoreTime() {
+    if (originalTimes.isEmpty()) return;
+    for (World world : IceCream.instance.getServer().getWorlds()) {
+      Long originalTime = originalTimes.get(world.getName());
+      if (originalTime != null) {
+        world.setFullTime(originalTime);
+      }
+    }
+    originalTimes.clear();
+  }
+
+  /** Applies the default World Tour environment across every loaded world. */
+  public void applyTourEnvironment() {
+    saveWeather();
+    saveTime();
+    saveKeepInventory();
+    enableKeepInventory();
+    setClearWeather();
+    setTime(startTimeTicks);
+  }
+
+  /** Saves the current keepInventory gamerule for every loaded world. */
+  public void saveKeepInventory() {
+    if (!originalKeepInventory.isEmpty()) return;
+    for (World world : IceCream.instance.getServer().getWorlds()) {
+      originalKeepInventory.put(world.getName(), world.getGameRuleValue(GameRules.KEEP_INVENTORY));
+    }
+  }
+
+  /** Enables keepInventory in every loaded world. */
+  public void enableKeepInventory() {
+    for (World world : IceCream.instance.getServer().getWorlds()) {
+      world.setGameRule(GameRules.KEEP_INVENTORY, true);
+    }
+  }
+
+  /** Restores the original keepInventory gamerule values for every saved world. */
+  public void restoreKeepInventory() {
+    if (originalKeepInventory.isEmpty()) return;
+    for (World world : IceCream.instance.getServer().getWorlds()) {
+      Boolean original = originalKeepInventory.get(world.getName());
+      if (original != null) {
+        world.setGameRule(GameRules.KEEP_INVENTORY, original);
+      }
+    }
+    originalKeepInventory.clear();
+  }
+
+  /** Cancels every active disconnect failsafe task. */
+  public void cancelAllDisconnectTasks() {
+    for (BukkitTask task : disconnectTasks.values()) {
+      if (task != null && !task.isCancelled()) {
+        task.cancel();
+      }
+    }
+    disconnectTasks.clear();
+  }
+
+  /**
+   * Cancels the disconnect failsafe task for a specific player.
+   *
+   * @param playerId the UUID of the player
+   */
+  public void cancelDisconnectTask(UUID playerId) {
+    BukkitTask task = disconnectTasks.remove(playerId);
+    if (task != null && !task.isCancelled()) {
+      task.cancel();
+    }
+  }
+
+  /**
+   * Schedules a disconnect failsafe task for a player.
+   *
+   * @param playerId the UUID of the player
+   * @param task the scheduled task
+   */
+  public void scheduleDisconnectTask(UUID playerId, BukkitTask task) {
+    BukkitTask existing = disconnectTasks.put(playerId, task);
+    if (existing != null && !existing.isCancelled()) {
+      existing.cancel();
+    }
+  }
+}

--- a/src/main/java/com/nearvanilla/iceCream/modules/worldTour/commands/WorldTourCommand.java
+++ b/src/main/java/com/nearvanilla/iceCream/modules/worldTour/commands/WorldTourCommand.java
@@ -108,7 +108,6 @@ public class WorldTourCommand {
    * Opt into the World Tour as a participant. Sets a persistent data flag so the player is
    * recognized on reconnect. Idempotent - returns an error if already joined.
    */
-
   @Command("worldtour join")
   @CommandDescription("Opt into the World Tour.")
   public void joinCommand(CommandSourceStack stack) {
@@ -130,7 +129,6 @@ public class WorldTourCommand {
    * player is the current host, the command is rejected - they must use /worldtour end to conclude
    * the tour for everyone.
    */
-
   @Command("worldtour leave")
   @CommandDescription("Opt out of the World Tour. Hosts must use /worldtour end instead.")
   public void leaveCommand(CommandSourceStack stack) {
@@ -161,7 +159,6 @@ public class WorldTourCommand {
    * configured start time, weather to clear, and keepInventory to true across all loaded
    * dimensions. Blocked if a tour is already ongoing.
    */
-
   @Command("worldtour start")
   @CommandDescription(
       "Start a World Tour: become host, set time to the configured start time, weather to clear, and enable keepInventory. Blocked if a tour is already ongoing.")
@@ -195,7 +192,6 @@ public class WorldTourCommand {
    * stores the pending request for confirmation. Rejected if the requester is already the host or
    * if no host is set.
    */
-
   @Command("worldtour takeover")
   @CommandDescription("Request to take over as World Tour host.")
   @Permission("icecream.modules.worldtour.host")
@@ -254,7 +250,6 @@ public class WorldTourCommand {
    * each teleported participant a notification. Reports the total count of teleported players back
    * to the host. Only usable by the current host.
    */
-
   @Command("worldtour tpall")
   @CommandDescription("Teleport all World Tour participants to the host.")
   @Permission("icecream.modules.worldtour.host")
@@ -293,7 +288,6 @@ public class WorldTourCommand {
    * Transfer the host's glowing effect to a specified target player. The target is notified that
    * they are now glowing. Only usable by the current host.
    */
-
   @Command("worldtour glow <player>")
   @CommandDescription("Transfer the host's Glowing effect to another player.")
   @Permission("icecream.modules.worldtour.host")
@@ -321,7 +315,6 @@ public class WorldTourCommand {
    * storage, clears the current host, and transfers host and glowing effect to the requester.
    * Notifies both parties of the result. Fails gracefully if the requester is no longer online.
    */
-
   @Command("worldtour takeover confirm")
   @CommandDescription("Accept a pending World Tour host takeover request.")
   @Permission("icecream.modules.worldtour.host")
@@ -363,7 +356,6 @@ public class WorldTourCommand {
    * and notifies the requester that their request was denied. Does not affect host status or tour
    * state.
    */
-
   @Command("worldtour takeover deny")
   @CommandDescription("Deny a pending World Tour host takeover request.")
   @Permission("icecream.modules.worldtour.host")
@@ -390,7 +382,6 @@ public class WorldTourCommand {
    * restore original time, weather, and keepInventory settings across all loaded dimensions. Only
    * usable by the current host. Rejects if no host is set or if the sender is not the host.
    */
-
   @Command("worldtour end")
   @CommandDescription("End the World Tour: clear the host and restore original environment.")
   @Permission("icecream.modules.worldtour.host")
@@ -420,7 +411,6 @@ public class WorldTourCommand {
    * environment settings. Does not check if the sender is the host, allowing admins and moderators
    * to clean up. Fails gracefully if no tour is active.
    */
-
   @Command("worldtour forceend")
   @CommandDescription("Force-end the World Tour as an admin or moderator.")
   @Permission("icecream.modules.worldtour.host")
@@ -443,7 +433,6 @@ public class WorldTourCommand {
    * (case-insensitive, autocompleted). Delegates to module.setWeather() which applies the change to
    * all dimensions. Only usable if a host is online. Returns an error for unknown weather types.
    */
-
   @Command("worldtour weather <type>")
   @CommandDescription("Change the weather across all loaded World Tour dimensions.")
   @Permission("icecream.modules.worldtour.host")
@@ -475,7 +464,6 @@ public class WorldTourCommand {
    * applies it via module.setTime(). Only usable if a host is online. Returns an error for unknown
    * time types.
    */
-
   @Command("worldtour time <type>")
   @CommandDescription("Change the time across all loaded World Tour dimensions.")
   @Permission("icecream.modules.worldtour.host")

--- a/src/main/java/com/nearvanilla/iceCream/modules/worldTour/commands/WorldTourCommand.java
+++ b/src/main/java/com/nearvanilla/iceCream/modules/worldTour/commands/WorldTourCommand.java
@@ -104,7 +104,10 @@ public class WorldTourCommand {
     return TIME_TYPES.stream().toList();
   }
 
-  /* ---- join ---- */
+  /**
+   * Opt into the World Tour as a participant. Sets a persistent data flag so the player is
+   * recognized on reconnect. Idempotent - returns an error if already joined.
+   */
 
   @Command("worldtour join")
   @CommandDescription("Opt into the World Tour.")
@@ -122,7 +125,11 @@ public class WorldTourCommand {
     player.sendMessage(JOINED);
   }
 
-  /* ---- leave ---- */
+  /**
+   * Opt out of the World Tour as a participant. Clears the joined persistent data flag. If the
+   * player is the current host, the command is rejected - they must use /worldtour end to conclude
+   * the tour for everyone.
+   */
 
   @Command("worldtour leave")
   @CommandDescription("Opt out of the World Tour. Hosts must use /worldtour end instead.")
@@ -148,7 +155,12 @@ public class WorldTourCommand {
     player.sendMessage(LEFT);
   }
 
-  /* ---- start ---- */
+  /**
+   * Become host and launch the World Tour. Sets the player as current host, applies the glowing
+   * effect, marks them as joined, and calls applyTourEnvironment() to set the time to the
+   * configured start time, weather to clear, and keepInventory to true across all loaded
+   * dimensions. Blocked if a tour is already ongoing.
+   */
 
   @Command("worldtour start")
   @CommandDescription(
@@ -177,7 +189,12 @@ public class WorldTourCommand {
     player.sendMessage(TOUR_STARTED);
   }
 
-  /* ---- takeover ---- */
+  /**
+   * Request to take over as World Tour host. If the current host is offline, automatically
+   * transfers host to the requester. If the host is online, sends them an accept/deny prompt and
+   * stores the pending request for confirmation. Rejected if the requester is already the host or
+   * if no host is set.
+   */
 
   @Command("worldtour takeover")
   @CommandDescription("Request to take over as World Tour host.")
@@ -232,7 +249,11 @@ public class WorldTourCommand {
     player.sendMessage(TAKEOVER_REQUEST_SENT);
   }
 
-  /* ---- tpall ---- */
+  /**
+   * Teleport every online participant (excluding the host) to the host's current location. Sends
+   * each teleported participant a notification. Reports the total count of teleported players back
+   * to the host. Only usable by the current host.
+   */
 
   @Command("worldtour tpall")
   @CommandDescription("Teleport all World Tour participants to the host.")
@@ -268,7 +289,10 @@ public class WorldTourCommand {
     }
   }
 
-  /* ---- glow ---- */
+  /**
+   * Transfer the host's glowing effect to a specified target player. The target is notified that
+   * they are now glowing. Only usable by the current host.
+   */
 
   @Command("worldtour glow <player>")
   @CommandDescription("Transfer the host's Glowing effect to another player.")
@@ -292,7 +316,11 @@ public class WorldTourCommand {
             .deserialize("<green>✓ You are now glowing for the World Tour!</green>"));
   }
 
-  /* ---- takeover confirm ---- */
+  /**
+   * Accept a pending takeover request as the current host. Removes the pending request from
+   * storage, clears the current host, and transfers host and glowing effect to the requester.
+   * Notifies both parties of the result. Fails gracefully if the requester is no longer online.
+   */
 
   @Command("worldtour takeover confirm")
   @CommandDescription("Accept a pending World Tour host takeover request.")
@@ -330,7 +358,11 @@ public class WorldTourCommand {
     }
   }
 
-  /* ---- takeover deny ---- */
+  /**
+   * Deny a pending takeover request as the current host. Removes the pending request from storage
+   * and notifies the requester that their request was denied. Does not affect host status or tour
+   * state.
+   */
 
   @Command("worldtour takeover deny")
   @CommandDescription("Deny a pending World Tour host takeover request.")
@@ -353,7 +385,11 @@ public class WorldTourCommand {
         MiniMessage.miniMessage().deserialize("<green>✓ Takeover request denied.</green>"));
   }
 
-  /* ---- end ---- */
+  /**
+   * End the World Tour as the current host. Calls endTour() on the module to clear the host,
+   * restore original time, weather, and keepInventory settings across all loaded dimensions. Only
+   * usable by the current host. Rejects if no host is set or if the sender is not the host.
+   */
 
   @Command("worldtour end")
   @CommandDescription("End the World Tour: clear the host and restore original environment.")
@@ -379,7 +415,11 @@ public class WorldTourCommand {
     player.sendMessage(TOUR_ENDED);
   }
 
-  /* ---- forceend ---- */
+  /**
+   * Force-end the World Tour regardless of host status. Calls endTour() to restore original
+   * environment settings. Does not check if the sender is the host, allowing admins and moderators
+   * to clean up. Fails gracefully if no tour is active.
+   */
 
   @Command("worldtour forceend")
   @CommandDescription("Force-end the World Tour as an admin or moderator.")
@@ -398,7 +438,11 @@ public class WorldTourCommand {
                 .deserialize("<green>✓ World Tour force-ended. Environment restored.</green>"));
   }
 
-  /* ---- weather ---- */
+  /**
+   * Set the weather across all loaded World Tour dimensions. Accepts clear, rain, or thunder
+   * (case-insensitive, autocompleted). Delegates to module.setWeather() which applies the change to
+   * all dimensions. Only usable if a host is online. Returns an error for unknown weather types.
+   */
 
   @Command("worldtour weather <type>")
   @CommandDescription("Change the weather across all loaded World Tour dimensions.")
@@ -425,7 +469,12 @@ public class WorldTourCommand {
     player.sendMessage(WEATHER_CHANGED);
   }
 
-  /* ---- time ---- */
+  /**
+   * Set the time across all loaded World Tour dimensions. Accepts day, night, noon, or midnight
+   * (case-insensitive, autocompleted). Converts the type to ticks via module.getTimeTicks() and
+   * applies it via module.setTime(). Only usable if a host is online. Returns an error for unknown
+   * time types.
+   */
 
   @Command("worldtour time <type>")
   @CommandDescription("Change the time across all loaded World Tour dimensions.")

--- a/src/main/java/com/nearvanilla/iceCream/modules/worldTour/commands/WorldTourCommand.java
+++ b/src/main/java/com/nearvanilla/iceCream/modules/worldTour/commands/WorldTourCommand.java
@@ -1,0 +1,473 @@
+package com.nearvanilla.iceCream.modules.worldTour.commands;
+
+import com.nearvanilla.iceCream.modules.worldTour.WorldTourModule;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataType;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
+
+/**
+ * WorldTourCommand provides all subcommands for the World Tour module: join, leave, start,
+ * takeover, tpall, glow, end, forceend, weather, and time.
+ *
+ * @author Demonstrations
+ * @version 1.0
+ * @since 2026-06-26
+ */
+@SuppressWarnings("unused")
+public class WorldTourCommand {
+
+  private static final Set<String> WEATHER_TYPES = Set.of("clear", "rain", "thunder");
+  private static final Set<String> TIME_TYPES = Set.of("day", "night", "noon", "midnight");
+
+  private static final Component JOINED =
+      MiniMessage.miniMessage().deserialize("<green>✓ You have joined the World Tour!</green>");
+  private static final Component LEFT =
+      MiniMessage.miniMessage().deserialize("<red>✓ You have left the World Tour.</red>");
+  private static final Component ALREADY_JOINED =
+      MiniMessage.miniMessage()
+          .deserialize("<red>✗ You are already participating in the World Tour!</red>");
+  private static final Component NOT_JOINED =
+      MiniMessage.miniMessage()
+          .deserialize("<red>✗ You are not participating in the World Tour.</red>");
+  private static final Component PLAYERS_ONLY =
+      MiniMessage.miniMessage()
+          .deserialize("<red>✗ This command can only be used by players.</red>");
+  private static final Component NO_HOST =
+      MiniMessage.miniMessage().deserialize("<red>✗ There is no World Tour host set.</red>");
+  private static final Component HOST_SET =
+      MiniMessage.miniMessage().deserialize("<green>✓ You are now the World Tour host!</green>");
+
+  private static final Component TAKEOVER_REQUEST_SENT =
+      MiniMessage.miniMessage()
+          .deserialize(
+              "<yellow>Takeover request sent. Waiting for the current host to respond.</yellow>");
+  private static final Component TAKEOVER_DENIED =
+      MiniMessage.miniMessage().deserialize("<red>✗ Your takeover request was denied.</red>");
+  private static final Component TAKEOVER_NO_REQUEST =
+      MiniMessage.miniMessage().deserialize("<red>✗ No pending takeover request found.</red>");
+  private static final Component TPALL_SUCCESS =
+      MiniMessage.miniMessage()
+          .deserialize("<green>✓ All participants have been teleported to you!</green>");
+  private static final Component TPALL_PARTICIPANT =
+      MiniMessage.miniMessage()
+          .deserialize("<green>✓ You have been teleported to the World Tour host.</green>");
+  private static final Component WEATHER_CHANGED =
+      MiniMessage.miniMessage().deserialize("<green>✓ Weather has been updated.</green>");
+  private static final Component TIME_CHANGED =
+      MiniMessage.miniMessage().deserialize("<green>✓ Time has been updated.</green>");
+  private static final Component UNKNOWN_WEATHER =
+      MiniMessage.miniMessage()
+          .deserialize("<red>✗ Unknown weather type. Use: clear, rain, or thunder.</red>");
+  private static final Component UNKNOWN_TIME =
+      MiniMessage.miniMessage()
+          .deserialize("<red>✗ Unknown time type. Use: day, night, noon, or midnight.</red>");
+  private static final Component TOUR_STARTED =
+      MiniMessage.miniMessage()
+          .deserialize(
+              "<green>✓ World Tour started! Time set to the configured start time, "
+                  + "weather set to clear, keepInventory enabled across all loaded dimensions.</green>");
+  private static final Component TOUR_ENDED =
+      MiniMessage.miniMessage()
+          .deserialize("<green>✓ World Tour ended. Environment restored.</green>");
+  private static final Component NOT_HOST =
+      MiniMessage.miniMessage()
+          .deserialize("<red>✗ Only the World Tour host can use this command.</red>");
+
+  private final WorldTourModule module;
+
+  public WorldTourCommand(WorldTourModule module) {
+    this.module = module;
+  }
+
+  @Suggestions("weather_types")
+  public List<String> suggestWeather(CommandContext<CommandSourceStack> ctx, CommandInput input) {
+    return WEATHER_TYPES.stream().toList();
+  }
+
+  @Suggestions("time_types")
+  public List<String> suggestTime(CommandContext<CommandSourceStack> ctx, CommandInput input) {
+    return TIME_TYPES.stream().toList();
+  }
+
+  /* ---- join ---- */
+
+  @Command("worldtour join")
+  @CommandDescription("Opt into the World Tour.")
+  public void joinCommand(CommandSourceStack stack) {
+    Player player = requirePlayer(stack);
+    if (player == null) return;
+
+    var container = player.getPersistentDataContainer();
+    if (Boolean.TRUE.equals(
+        container.get(WorldTourModule.JOINED_KEY, PersistentDataType.BOOLEAN))) {
+      player.sendMessage(ALREADY_JOINED);
+      return;
+    }
+    container.set(WorldTourModule.JOINED_KEY, PersistentDataType.BOOLEAN, true);
+    player.sendMessage(JOINED);
+  }
+
+  /* ---- leave ---- */
+
+  @Command("worldtour leave")
+  @CommandDescription("Opt out of the World Tour. Hosts must use /worldtour end instead.")
+  public void leaveCommand(CommandSourceStack stack) {
+    Player player = requirePlayer(stack);
+    if (player == null) return;
+
+    if (player.equals(module.getCurrentHost())) {
+      player.sendMessage(
+          MiniMessage.miniMessage()
+              .deserialize(
+                  "<red>✗ You are the host. Use <click:run_command:/worldtour end>/worldtour end</click> to conclude the tour. <gray>This will end the tour for all participants.</gray></red>"));
+      return;
+    }
+
+    var container = player.getPersistentDataContainer();
+    if (!Boolean.TRUE.equals(
+        container.get(WorldTourModule.JOINED_KEY, PersistentDataType.BOOLEAN))) {
+      player.sendMessage(NOT_JOINED);
+      return;
+    }
+    container.set(WorldTourModule.JOINED_KEY, PersistentDataType.BOOLEAN, false);
+    player.sendMessage(LEFT);
+  }
+
+  /* ---- start ---- */
+
+  @Command("worldtour start")
+  @CommandDescription(
+      "Start a World Tour: become host, set time to the configured start time, weather to clear, and enable keepInventory. Blocked if a tour is already ongoing.")
+  @Permission("icecream.modules.worldtour.host")
+  public void startCommand(CommandSourceStack stack) {
+    Player player = requirePlayer(stack);
+    if (player == null) return;
+
+    // A tour is already ongoing — block.
+    if (module.getCurrentHost() != null) {
+      player.sendMessage(
+          MiniMessage.miniMessage()
+              .deserialize(
+                  "<red>✗ A World Tour is already ongoing. Use <click:run_command:/worldtour takeover>/worldtour takeover</click> to request host.</red>"));
+      return;
+    }
+
+    // Become host and apply environment.
+    module.setCurrentHost(player);
+    module.setGlowing(player);
+    player
+        .getPersistentDataContainer()
+        .set(WorldTourModule.JOINED_KEY, PersistentDataType.BOOLEAN, true);
+    applyTourEnvironment();
+    player.sendMessage(TOUR_STARTED);
+  }
+
+  /* ---- takeover ---- */
+
+  @Command("worldtour takeover")
+  @CommandDescription("Request to take over as World Tour host.")
+  @Permission("icecream.modules.worldtour.host")
+  public void takeoverCommand(CommandSourceStack stack) {
+    Player player = requirePlayer(stack);
+    if (player == null) return;
+
+    Player currentHost = module.getCurrentHost();
+
+    if (player.equals(currentHost)) {
+      player.sendMessage(
+          MiniMessage.miniMessage()
+              .deserialize("<red>✗ You are already the World Tour host.</red>"));
+      return;
+    }
+    if (currentHost == null) {
+      player.sendMessage(NO_HOST);
+      return;
+    }
+
+    // Host is offline — auto-transfer.
+    if (!currentHost.isOnline()) {
+      module.clearHost(false);
+      module.setCurrentHost(player);
+      module.setGlowing(player);
+      player
+          .getPersistentDataContainer()
+          .set(WorldTourModule.JOINED_KEY, PersistentDataType.BOOLEAN, true);
+      player.sendMessage(HOST_SET);
+      player.sendMessage(
+          MiniMessage.miniMessage()
+              .deserialize("<gray>The previous host was offline. Tour continues.</gray>"));
+      return;
+    }
+
+    module.setPendingTakeover(currentHost.getUniqueId(), player.getUniqueId());
+
+    Component acceptBtn =
+        Component.text("[Accept]", NamedTextColor.GREEN)
+            .clickEvent(ClickEvent.runCommand("/worldtour takeover confirm"));
+    Component denyBtn =
+        Component.text("[Deny]", NamedTextColor.RED)
+            .clickEvent(ClickEvent.runCommand("/worldtour takeover deny"));
+    Component requestMsg =
+        Component.text(
+                player.getName() + " wants to take over as World Tour host. ", NamedTextColor.GOLD)
+            .append(acceptBtn)
+            .append(Component.space())
+            .append(denyBtn);
+    currentHost.sendMessage(requestMsg);
+    player.sendMessage(TAKEOVER_REQUEST_SENT);
+  }
+
+  /* ---- tpall ---- */
+
+  @Command("worldtour tpall")
+  @CommandDescription("Teleport all World Tour participants to the host.")
+  @Permission("icecream.modules.worldtour.host")
+  public void tpallCommand(CommandSourceStack stack) {
+    Player player = requirePlayer(stack);
+    if (player == null) return;
+
+    if (!player.equals(module.getCurrentHost())) {
+      player.sendMessage(NOT_HOST);
+      return;
+    }
+
+    Player host = module.getCurrentHost();
+
+    int count = 0;
+    for (Player online : player.getServer().getOnlinePlayers()) {
+      if (online.equals(host)) continue;
+      if (Boolean.TRUE.equals(
+          online
+              .getPersistentDataContainer()
+              .get(WorldTourModule.JOINED_KEY, PersistentDataType.BOOLEAN))) {
+        online.teleport(host.getLocation());
+        online.sendMessage(TPALL_PARTICIPANT);
+        count++;
+      }
+    }
+    player.sendMessage(TPALL_SUCCESS);
+    if (count > 0) {
+      player.sendMessage(
+          MiniMessage.miniMessage()
+              .deserialize("<green>" + count + " participant(s) teleported.</green>"));
+    }
+  }
+
+  /* ---- glow ---- */
+
+  @Command("worldtour glow <player>")
+  @CommandDescription("Transfer the host's Glowing effect to another player.")
+  @Permission("icecream.modules.worldtour.host")
+  public void glowCommand(CommandSourceStack stack, @Argument(value = "player") Player target) {
+    Player player = requirePlayer(stack);
+    if (player == null) return;
+
+    if (!player.equals(module.getCurrentHost())) {
+      player.sendMessage(NOT_HOST);
+      return;
+    }
+
+    module.setGlowing(target);
+    player.sendMessage(
+        MiniMessage.miniMessage()
+            .deserialize(
+                "<green>✓ Glowing effect transferred to " + target.getName() + ".</green>"));
+    target.sendMessage(
+        MiniMessage.miniMessage()
+            .deserialize("<green>✓ You are now glowing for the World Tour!</green>"));
+  }
+
+  /* ---- takeover confirm ---- */
+
+  @Command("worldtour takeover confirm")
+  @CommandDescription("Accept a pending World Tour host takeover request.")
+  @Permission("icecream.modules.worldtour.host")
+  public void takeoverConfirmCommand(CommandSourceStack stack) {
+    Player player = requirePlayer(stack);
+    if (player == null) return;
+
+    UUID requesterId = module.removePendingTakeover(player.getUniqueId());
+    if (requesterId == null) {
+      player.sendMessage(TAKEOVER_NO_REQUEST);
+      return;
+    }
+
+    Player requester = player.getServer().getPlayer(requesterId);
+
+    // Transfer host to the requester.
+    module.clearHost(false);
+
+    if (requester != null && requester.isOnline()) {
+      module.setCurrentHost(requester);
+      module.setGlowing(requester);
+      requester
+          .getPersistentDataContainer()
+          .set(WorldTourModule.JOINED_KEY, PersistentDataType.BOOLEAN, true);
+      requester.sendMessage(HOST_SET);
+      player.sendMessage(
+          MiniMessage.miniMessage()
+              .deserialize(
+                  "<green>✓ " + requester.getName() + " is now the World Tour host.</green>"));
+    } else {
+      player.sendMessage(
+          MiniMessage.miniMessage()
+              .deserialize("<red>✗ The requesting player is no longer online.</red>"));
+    }
+  }
+
+  /* ---- takeover deny ---- */
+
+  @Command("worldtour takeover deny")
+  @CommandDescription("Deny a pending World Tour host takeover request.")
+  @Permission("icecream.modules.worldtour.host")
+  public void takeoverDenyCommand(CommandSourceStack stack) {
+    Player player = requirePlayer(stack);
+    if (player == null) return;
+
+    UUID requesterId = module.removePendingTakeover(player.getUniqueId());
+    if (requesterId == null) {
+      player.sendMessage(TAKEOVER_NO_REQUEST);
+      return;
+    }
+
+    Player requester = player.getServer().getPlayer(requesterId);
+    if (requester != null && requester.isOnline()) {
+      requester.sendMessage(TAKEOVER_DENIED);
+    }
+    player.sendMessage(
+        MiniMessage.miniMessage().deserialize("<green>✓ Takeover request denied.</green>"));
+  }
+
+  /* ---- end ---- */
+
+  @Command("worldtour end")
+  @CommandDescription("End the World Tour: clear the host and restore original environment.")
+  @Permission("icecream.modules.worldtour.host")
+  public void endCommand(CommandSourceStack stack) {
+    Player player = requirePlayer(stack);
+    if (player == null) return;
+
+    Player currentHost = module.getCurrentHost();
+    if (currentHost == null) {
+      player.sendMessage(NO_HOST);
+      return;
+    }
+
+    if (!player.equals(currentHost)) {
+      player.sendMessage(
+          MiniMessage.miniMessage()
+              .deserialize("<red>✗ Only the World Tour host can end the tour.</red>"));
+      return;
+    }
+
+    module.endTour();
+    player.sendMessage(TOUR_ENDED);
+  }
+
+  /* ---- forceend ---- */
+
+  @Command("worldtour forceend")
+  @CommandDescription("Force-end the World Tour as an admin or moderator.")
+  @Permission("icecream.modules.worldtour.host")
+  public void forceEndCommand(CommandSourceStack stack) {
+    if (module.getCurrentHost() == null) {
+      stack.getSender().sendMessage(NO_HOST);
+      return;
+    }
+
+    module.endTour();
+    stack
+        .getSender()
+        .sendMessage(
+            MiniMessage.miniMessage()
+                .deserialize("<green>✓ World Tour force-ended. Environment restored.</green>"));
+  }
+
+  /* ---- weather ---- */
+
+  @Command("worldtour weather <type>")
+  @CommandDescription("Change the weather across all loaded World Tour dimensions.")
+  @Permission("icecream.modules.worldtour.host")
+  public void weatherCommand(
+      CommandSourceStack stack,
+      @Argument(value = "type", suggestions = "weather_types") String type) {
+    Player player = requirePlayer(stack);
+    if (player == null) return;
+
+    Player host = module.getCurrentHost();
+    if (host == null || !host.isOnline()) {
+      player.sendMessage(NO_HOST);
+      return;
+    }
+
+    type = type.toLowerCase(Locale.ROOT);
+    if (!WEATHER_TYPES.contains(type)) {
+      player.sendMessage(UNKNOWN_WEATHER);
+      return;
+    }
+
+    module.setWeather(type);
+    player.sendMessage(WEATHER_CHANGED);
+  }
+
+  /* ---- time ---- */
+
+  @Command("worldtour time <type>")
+  @CommandDescription("Change the time across all loaded World Tour dimensions.")
+  @Permission("icecream.modules.worldtour.host")
+  public void timeCommand(
+      CommandSourceStack stack, @Argument(value = "type", suggestions = "time_types") String type) {
+    Player player = requirePlayer(stack);
+    if (player == null) return;
+
+    Player host = module.getCurrentHost();
+    if (host == null || !host.isOnline()) {
+      player.sendMessage(NO_HOST);
+      return;
+    }
+
+    type = type.toLowerCase(Locale.ROOT);
+    if (!TIME_TYPES.contains(type)) {
+      player.sendMessage(UNKNOWN_TIME);
+      return;
+    }
+
+    module.setTime(module.getTimeTicks(type));
+    player.sendMessage(TIME_CHANGED);
+  }
+
+  /**
+   * Extracts a player from the command source stack, sending an error message if the sender is not
+   * a player.
+   *
+   * @param stack the command source stack
+   * @return the player, or {@code null} if the sender is not a player
+   */
+  private static Player requirePlayer(CommandSourceStack stack) {
+    if (!(stack.getSender() instanceof Player player)) {
+      stack.getSender().sendMessage(PLAYERS_ONLY);
+      return null;
+    }
+    return player;
+  }
+
+  /** Saves the current environment, then applies day time, clear weather, and keepInventory. */
+  private void applyTourEnvironment() {
+    module.applyTourEnvironment();
+  }
+}

--- a/src/main/java/com/nearvanilla/iceCream/modules/worldTour/events/WorldTourListener.java
+++ b/src/main/java/com/nearvanilla/iceCream/modules/worldTour/events/WorldTourListener.java
@@ -1,0 +1,87 @@
+package com.nearvanilla.iceCream.modules.worldTour.events;
+
+import com.nearvanilla.iceCream.IceCream;
+import com.nearvanilla.iceCream.modules.worldTour.WorldTourModule;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.persistence.PersistentDataType;
+
+/**
+ * WorldTourListener implements the disconnect failsafe for World Tour participants. When a
+ * non-host participant disconnects and does not return within the configured timeout, they are
+ * automatically opted out. Host disconnects do not automatically end the tour.
+ *
+ * @author Demonstrations
+ * @version 1.0
+ * @since 2026-06-26
+ */
+public class WorldTourListener implements Listener {
+
+  private final WorldTourModule module;
+
+  public WorldTourListener(WorldTourModule module) {
+    this.module = module;
+  }
+
+  @EventHandler
+  public void onPlayerQuit(PlayerQuitEvent event) {
+    Player player = event.getPlayer();
+
+    // Clear glow tracking if this player was the glowing one.
+    if (player.equals(module.getCurrentGlowing())) {
+      module.clearGlowing();
+    }
+
+    // Host disconnects do not automatically end the tour. Also skip the normal participant
+    // auto-opt-out path, because the host is marked as joined while a tour is active.
+    if (player.equals(module.getCurrentHost())) {
+      return;
+    }
+
+    long timeoutTicks = module.getFailsafeTimeoutMinutes() * 60L * 20L;
+
+    // If the player is a participant, schedule auto-opt-out.
+    if (Boolean.TRUE.equals(
+        player
+            .getPersistentDataContainer()
+            .get(WorldTourModule.JOINED_KEY, PersistentDataType.BOOLEAN))) {
+      var task =
+          IceCream.instance
+              .getServer()
+              .getScheduler()
+              .runTaskLater(
+                  IceCream.instance,
+                  () -> {
+                    module.cancelDisconnectTask(player.getUniqueId());
+                    if (!player.isOnline()) {
+                      player
+                          .getPersistentDataContainer()
+                          .set(WorldTourModule.JOINED_KEY, PersistentDataType.BOOLEAN, false);
+                      player.saveData();
+                    }
+                  },
+                  timeoutTicks);
+      module.scheduleDisconnectTask(player.getUniqueId(), task);
+    }
+  }
+
+  @EventHandler
+  public void onPlayerJoin(PlayerJoinEvent event) {
+    Player player = event.getPlayer();
+    module.cancelDisconnectTask(player.getUniqueId());
+
+    // Clean up stale join flag if no tour is active.
+    if (module.getCurrentHost() == null
+        && Boolean.TRUE.equals(
+            player
+                .getPersistentDataContainer()
+                .get(WorldTourModule.JOINED_KEY, PersistentDataType.BOOLEAN))) {
+      player
+          .getPersistentDataContainer()
+          .set(WorldTourModule.JOINED_KEY, PersistentDataType.BOOLEAN, false);
+    }
+  }
+}

--- a/src/main/java/com/nearvanilla/iceCream/modules/worldTour/events/WorldTourListener.java
+++ b/src/main/java/com/nearvanilla/iceCream/modules/worldTour/events/WorldTourListener.java
@@ -26,6 +26,12 @@ public class WorldTourListener implements Listener {
     this.module = module;
   }
 
+  /**
+   * Clear glow tracking if the quitting player was glowing. Skip auto-opt-out for the host (host
+   * disconnect does not end the tour). For participants, schedule a failsafe task that opts them
+   * out if they do not return within the configured timeout.
+   */
+
   @EventHandler
   public void onPlayerQuit(PlayerQuitEvent event) {
     Player player = event.getPlayer();
@@ -67,6 +73,11 @@ public class WorldTourListener implements Listener {
       module.scheduleDisconnectTask(player.getUniqueId(), task);
     }
   }
+
+  /**
+   * Cancel the disconnect failsafe task for the rejoining player. If no tour is active, clean up
+   * any stale join flag left behind from a prior session.
+   */
 
   @EventHandler
   public void onPlayerJoin(PlayerJoinEvent event) {

--- a/src/main/java/com/nearvanilla/iceCream/modules/worldTour/events/WorldTourListener.java
+++ b/src/main/java/com/nearvanilla/iceCream/modules/worldTour/events/WorldTourListener.java
@@ -31,7 +31,6 @@ public class WorldTourListener implements Listener {
    * disconnect does not end the tour). For participants, schedule a failsafe task that opts them
    * out if they do not return within the configured timeout.
    */
-
   @EventHandler
   public void onPlayerQuit(PlayerQuitEvent event) {
     Player player = event.getPlayer();
@@ -78,7 +77,6 @@ public class WorldTourListener implements Listener {
    * Cancel the disconnect failsafe task for the rejoining player. If no tour is active, clean up
    * any stale join flag left behind from a prior session.
    */
-
   @EventHandler
   public void onPlayerJoin(PlayerJoinEvent event) {
     Player player = event.getPlayer();

--- a/src/main/java/com/nearvanilla/iceCream/modules/worldTour/events/WorldTourListener.java
+++ b/src/main/java/com/nearvanilla/iceCream/modules/worldTour/events/WorldTourListener.java
@@ -10,9 +10,9 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.persistence.PersistentDataType;
 
 /**
- * WorldTourListener implements the disconnect failsafe for World Tour participants. When a
- * non-host participant disconnects and does not return within the configured timeout, they are
- * automatically opted out. Host disconnects do not automatically end the tour.
+ * WorldTourListener implements the disconnect failsafe for World Tour participants. When a non-host
+ * participant disconnects and does not return within the configured timeout, they are automatically
+ * opted out. Host disconnects do not automatically end the tour.
  *
  * @author Demonstrations
  * @version 1.0

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -79,3 +79,13 @@ modules:
           D: DIAMOND
           A: ARMOR_STAND
           H: STICK
+  worldtour:
+    enabled: true
+    failsafe-timeout-minutes: 10
+    start-time-ticks: 1000
+    times:
+      day: 1000
+      noon: 6000
+      night: 13000
+      midnight: 18000
+


### PR DESCRIPTION
## Added

- World tour module

`icecream.modules.worldtour.host` is intended for mods/admins, dont think helpers will need any of the commands but I can change if needed

## Player commands

No permission required.

`/worldtour join` — Join the World Tour.

`/worldtour leave` — Leave the World Tour. Hosts must use `/worldtour end`.

## Host commands

Permission: `icecream.modules.worldtour.host`

`/worldtour start` — Start a tour and become host.

`/worldtour takeover` — Request/take over host.

`/worldtour tpall` — Teleport joined players to host.

`/worldtour glow <player>` — Move glowing effect to another player.

`/worldtour end` — End the tour normally.

`/worldtour forceend` — Force-end a stuck tour.

`/worldtour weather <clear|rain|thunder>` — Set weather across loaded dimensions.

`/worldtour time <day|noon|night|midnight>` — Set time using configured tick values.

## Hidden click commands

Permission: `icecream.modules.worldtour.host`

`/worldtour takeover confirm` — Accept takeover.

`/worldtour takeover deny` — Deny takeover.